### PR TITLE
Fix compilation on earlier kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For kernels 3.19 and later a new mac80211 driver was written from scratch by the
 First install kernel-devel for your Linux distro
 
 ```sh
-$ git clone https://github.com/porjo/mt7601.git
+$ git clone https://github.com/art567/mt7601usta.git
 $ cd mt7601/src
 $ make
 $ mkdir -p /etc/Wireless/RT2870STA/

--- a/src/include/os/rt_linux.h
+++ b/src/include/os/rt_linux.h
@@ -282,6 +282,9 @@ typedef struct _OS_FS_INFO_
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,12,0) || defined (SYNOLOGY)
 	uid_t				fsuid;
 	gid_t				fsgid;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,29)
+	int				fsuid;
+	int				fsgid;
 #else
 	kuid_t				fsuid;
 	kgid_t				fsgid;


### PR DESCRIPTION
Fixed compilation on kernel branch 2.6.x (2.6.29 - 2.6.32).
Added distro's support such as CentOS 6.x and Ubuntu 12.04 LTS.